### PR TITLE
fix(zitadel): make admin-created users loginable and fix permission save (405)

### DIFF
--- a/backend/src/modules/zitadel/ZitadelService.ts
+++ b/backend/src/modules/zitadel/ZitadelService.ts
@@ -1077,7 +1077,13 @@ class ZitadelService {
             },
             email: {
                 email: params.email,
-                isEmailVerified: false
+                // When an admin provisions the account with a password, mark the
+                // email verified so the user is immediately active and can log in.
+                // Without this the user stays in INITIAL state and requires an
+                // email-based activation flow, which is unavailable in deployments
+                // without a configured mail server. When no password is supplied
+                // (e.g. migrations relying on a reset email), leave it unverified.
+                isEmailVerified: Boolean(params.password)
             },
             requestPasswordlessRegistration: false
         };
@@ -1199,8 +1205,10 @@ class ZitadelService {
 
         const encoded = Buffer.from(JSON.stringify(config)).toString('base64');
 
+        // Zitadel's Management API exposes SetUserMetadata as POST (not PUT) on
+        // this path; using PUT returns 405 Method Not Allowed.
         await this.request(
-            'PUT',
+            'POST',
             `/management/v1/users/${userId}/metadata/${FM_PERMISSIONS_KEY}`,
             {value: encoded}
         );


### PR DESCRIPTION
## Summary

User administration from the Fleet Manager UI is broken against current Zitadel (tested `v2.64.1`). Two independent Management API bugs, both in `backend/src/modules/zitadel/ZitadelService.ts`:

1. **Saving permissions fails with 405.** `setFmPermissions` issues `PUT /management/v1/users/{id}/metadata/{key}`, but Zitadel's `SetUserMetadata` is a `POST`. Every "Save permissions" action fails.
2. **Admin-created users cannot log in.** `createHumanUser` always sends `isEmailVerified: false`, so the account stays in `INITIAL` state and needs an email-based activation step. In deployments without a mail server (e.g. the `deploy-public` community stack) there is no way to complete it, so the user is stuck at the "Activate User" page.

Both failures surface in the UI as a misleading `RPC timeout after 30000ms` — the backend actually returns the real error in well under a second, but the frontend never renders it. That frontend behaviour is a separate issue and is not addressed here.

## Changes

- `setFmPermissions`: `PUT` → `POST` on the metadata endpoint.
- `createHumanUser`: set `isEmailVerified` to `true` when the admin provisions a password, so the account is immediately active and loginable. When no password is supplied (e.g. `scripts/migrate-users-to-zitadel.ts`, which relies on a password-reset email) it stays `false`, preserving that flow.

## Reproduction (on a deploy-public stack)

1. Admin creates a user **with a password** → user is created but stuck in `INITIAL`; login shows the "Activate User" page.
2. Admin sets that user's permissions → `RPC timeout after 30000ms`; backend logs `Zitadel API error: 405 ... PUT /management/v1/users/{id}/metadata/fm_permissions`.

## Testing

Verified against `ghcr.io/zitadel/zitadel:v2.64.1`:

- `POST /management/v1/users/{id}/metadata/{key}` returns `200` (the `PUT` variant returns `405`).
- A user created with `isEmailVerified: true` + password lands in `ACTIVE` and completes OIDC login + token introspection as `admin`/`installer`; the unverified variant stops at "Activate User".

Change is limited to two call sites with no public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
