### PR TITLE
fix(device): gate Device.GetSetup on configurations:read (unblocks FMA installer provisioning)

### DIFF
--- a/backend/src/model/component/DeviceComponent.ts
+++ b/backend/src/model/component/DeviceComponent.ts
@@ -1047,7 +1047,13 @@ export default class DeviceComponent extends Component<any> {
     }
 
     @Component.Expose('GetSetup')
-    @Component.CrudPermission('devices', 'read', (params) => params?.shellyID)
+    // Gate on configurations:read — the data returned here is the config-profile
+    // catalog, not a device. Gating on devices:read for params.shellyID breaks
+    // installer provisioning (e.g. the FMA app): the target device isn't admitted
+    // yet, so the per-device check resolves to no organization and always denies,
+    // returning an empty catalog. The method already re-checks configurations:read
+    // internally. (Before 1.90 this method was @NoPermissions.)
+    @Component.CrudPermission('configurations', 'read')
     async getSetup(rawParams: unknown, sender: CommandSender) {
         const {mode = 'json'} = validateOrThrow<DeviceGetSetupParams>(
             rawParams,


### PR DESCRIPTION
Fixes #25.

## Problem
`Device.GetSetup` returns the config-profile catalog (`Storage.GetAll 'configs'`), but in 1.90 it's gated with:
```ts
@Component.CrudPermission('devices', 'read', (params) => params?.shellyID)
```
That per-device check resolves the `shellyID` to an organization, so during installer provisioning (the FMA app) — where the target device isn't admitted yet and has no organization — it always denies with `PermissionDenied`, and the app's profile/config selectors come back empty. It fails for a correctly-scoped `installer`, and even for Fleet Manager's own service token; only instance-level `IAM_OWNER` bypasses it. In 1.80 the method was `@NoPermissions`, so this is a regression.

## Change
Gate `getSetup` on `configurations:read` — the data returned is the config catalog, not a device:
```ts
@Component.Expose('GetSetup')
@Component.CrudPermission('configurations', 'read')
async getSetup(rawParams, sender) { ... }
```
The method already performs an internal `configurations:read` check, so this only aligns the decorator with the data it serves. No elevated privileges; an installer-scoped service user can provision again. The other per-device `devices:read` gates are untouched.

## Testing
Verified on a self-hosted 1.90.0 stack:
- **Before:** `Device.GetSetup {mode:"rpc"}` → `Caller is not authorized for this operation` (1001) for an `installer`/`admin` service user *and* for FM's own service token.
- **After:** returns the config-profile catalog (e.g. `{"Casa":{"casa-config":[…]}}`), and the FMA provisioning selectors populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
