### PR TITLE
fix(ingress): bound the waiting-room gather so a stuck one can't loop forever

### DIFF
--- a/backend/scripts/repro-gather-deadlock.ts
+++ b/backend/scripts/repro-gather-deadlock.ts
@@ -1,0 +1,190 @@
+/**
+ * Reproduces the permanent device-init loop (init-slot STUCK … stage=build)
+ * with no hardware and no network — see issues #28 and #30.
+ *
+ * What a device on a bad link does, and what this script recreates:
+ *
+ *   1. The waiting-room gather starts. Shelly.GetDeviceInfo / GetStatus /
+ *      GetConfig answer; ListMethods is still in flight when the link drops.
+ *   2. `ws` closes the socket, so WebSocketTransport tears down and
+ *      RpcTransport.destroy() rejects the pending RPCs — and clears the
+ *      stale-message sweeper.
+ *   3. getData() only WARNS on a ListMethods rejection, so the gather keeps
+ *      going with `methods = []`. That skips the component probe and lands
+ *      straight on Webhook.ListAllSupported.
+ *   4. That send registers a pending RPC on the dead transport. ws.send() is
+ *      a silent no-op once closed (no callback → sendAfterClose does nothing),
+ *      so nothing ever resolves it, and the sweeper that would have timed it
+ *      out is gone.
+ *   5. The gather promise never settles, so SingleFlight never clears its
+ *      entry. Every later connection dedups onto it and sends no RPCs at all,
+ *      until the 90s init-slot watchdog reclaims — forever. Only a process
+ *      restart clears it.
+ *
+ * Run it:
+ *   npx tsx backend/scripts/repro-gather-deadlock.ts
+ *
+ * On unpatched code it reports DEADLOCK; with the gather deadlines in place
+ * it recovers unattended. Override FM_DEVICE_INIT_PROBE_TIMEOUT_MS /
+ * FM_WAITING_GATHER_MAX_MS to make it finish faster.
+ */
+
+import './bench-events-env';
+import {EventEmitter} from 'node:events';
+import ShellyDeviceFactory from '../src/model/ShellyDeviceFactory';
+import WebSocketTransport from '../src/model/transport/WebsocketTransport';
+import {
+    clearGatheredDataForTests,
+    gatherDeviceDataOnce,
+    takeGatheredData
+} from '../src/modules/deviceIngress/gatheredDeviceData';
+
+const SHELLY_ID = 'shellypro2pm-ec6260887e94';
+// Comfortably past the shipped probe (20s) and gather (45s) deadlines, so a
+// pass means the code recovered rather than that we ran out of patience.
+// Lower it via REPRO_PATIENCE_MS when demonstrating the unpatched failure —
+// there is nothing to wait for in that case.
+const PATIENCE_MS = Number(process.env.REPRO_PATIENCE_MS ?? 60_000);
+
+/**
+ * Stand-in for a `ws` socket. Only two behaviours matter here: `send()` is a
+ * silent no-op once the socket is closed (that is what `ws` does when no send
+ * callback is supplied), and `close` fires on teardown.
+ */
+class FakeWs extends EventEmitter {
+    readyState = 1;
+    readonly framesOut: {id: number; method: string}[] = [];
+
+    send(data: string): void {
+        if (this.readyState !== 1) return;
+        this.framesOut.push(JSON.parse(data));
+    }
+
+    close(): void {}
+
+    /** Answer one already-sent request by method name. */
+    reply(method: string, result: unknown): void {
+        const req = this.framesOut.find((f) => f.method === method);
+        if (!req) throw new Error(`no pending ${method} to reply to`);
+        this.emit(
+            'message',
+            JSON.stringify({jsonrpc: '2.0', id: req.id, result})
+        );
+    }
+
+    /** The link drops: ws closes, the transport tears down. */
+    die(): void {
+        this.readyState = 3;
+        this.emit('close');
+    }
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Elapsed ms once `p` settles, or null if it outlasts PATIENCE_MS. */
+async function timeToSettle(p: Promise<unknown>): Promise<number | null> {
+    const startedAt = Date.now();
+    const stillPending = Symbol('pending');
+    const outcome = await Promise.race([
+        p.then(
+            () => 'resolved',
+            () => 'rejected'
+        ),
+        wait(PATIENCE_MS).then(() => stillPending)
+    ]);
+    return outcome === stillPending ? null : Date.now() - startedAt;
+}
+
+function report(label: string, value: string): void {
+    console.log(`${label.padEnd(22, '.')} ${value}`);
+}
+
+async function main(): Promise<number> {
+    clearGatheredDataForTests();
+    let gatherRuns = 0;
+
+    // --- connection 1: the link drops mid-gather --------------------------
+    const ws1 = new FakeWs();
+    const transport1 = new WebSocketTransport(ws1 as never);
+    const gather = gatherDeviceDataOnce(SHELLY_ID, (signal) => {
+        gatherRuns++;
+        return ShellyDeviceFactory.gatherDeviceData(transport1, signal);
+    });
+    gather.catch(() => undefined);
+
+    await tick();
+    report('probes sent', ws1.framesOut.map((f) => f.method).join(', '));
+
+    ws1.reply('Shelly.GetDeviceInfo', {
+        id: SHELLY_ID,
+        fw_id: '20260101-000000'
+    });
+    ws1.reply('Shelly.GetStatus', {});
+    ws1.reply('Shelly.GetConfig', {});
+    await tick();
+    ws1.die();
+    report('link dropped', 'mid-gather, ListMethods unanswered');
+
+    const gatherMs = await timeToSettle(gather);
+    report(
+        'gather settles',
+        gatherMs === null
+            ? `NO — still pending after ${PATIENCE_MS}ms`
+            : `yes, ${gatherMs}ms`
+    );
+    report(
+        'frames on dead sock',
+        `${ws1.framesOut.length} (unchanged — nothing left the process)`
+    );
+
+    // --- connection 2: the device reconnects ------------------------------
+    const ws2 = new FakeWs();
+    const transport2 = new WebSocketTransport(ws2 as never);
+    const runsBefore = gatherRuns;
+    const second = gatherDeviceDataOnce(SHELLY_ID, (signal) => {
+        gatherRuns++;
+        return ShellyDeviceFactory.gatherDeviceData(transport2, signal);
+    });
+    second.catch(() => undefined);
+    await tick();
+
+    // A fresh gather and a warm-cache hit are both fine. Joining the dead run
+    // is not — that is the failure this reproduces.
+    const secondMs = await timeToSettle(second);
+    report(
+        'reconnect',
+        secondMs === null
+            ? `HANGS — joined the dead run (${PATIENCE_MS}ms)`
+            : `resolves in ${secondMs}ms (fresh gather=${gatherRuns > runsBefore}, RPCs sent=${ws2.framesOut.length})`
+    );
+
+    // --- the accept path ---------------------------------------------------
+    const acceptMs = await timeToSettle(takeGatheredData(SHELLY_ID));
+    report(
+        'accept returns',
+        acceptMs === null ? `NO — hung ${PATIENCE_MS}ms` : `yes, ${acceptMs}ms`
+    );
+
+    const healed = gatherMs !== null && secondMs !== null && acceptMs !== null;
+    console.log(
+        healed
+            ? '\nRESULT: recovers unattended — the device registers on reconnect'
+            : '\nRESULT: DEADLOCK — reproduces issues #28 / #30'
+    );
+    return healed ? 0 : 1;
+}
+
+// The gather deadline unrefs its timer by design, so a bare script would exit
+// before it fires. Hold the loop open for the duration of the run.
+const keepAlive = setInterval(() => {}, 1000);
+main()
+    .then((code) => {
+        clearInterval(keepAlive);
+        process.exit(code);
+    })
+    .catch((err) => {
+        clearInterval(keepAlive);
+        console.error(err);
+        process.exit(2);
+    });

--- a/backend/src/config/tuning.ts
+++ b/backend/src/config/tuning.ts
@@ -972,6 +972,13 @@ export interface TuningConfig {
         probeConcurrency: number;
         /** Heavier gather (paginated components) fan-out cap (default: 50). */
         gatherConcurrency: number;
+        /** Hard deadline for one gather, every probe RPC included (default:
+         * 45s). Keep it under device.initSlotMaxHoldMs so a slow gather is
+         * given up on before the init-slot watchdog reclaims the slot. */
+        gatherMaxMs: number;
+        /** How long an accept waits on an already-running gather before
+         * abandoning it and probing fresh (default: 15s). */
+        gatherTakeMs: number;
     };
     ws: {
         /** Max queued WS messages from a client during token validation (default: 25) */
@@ -2590,6 +2597,8 @@ function readTuning(): TuningConfig {
             ),
             probeConcurrency: envInt('FM_WAITING_PROBE_CONCURRENCY', 50, 1),
             gatherConcurrency: envInt('FM_WAITING_GATHER_CONCURRENCY', 50, 1),
+            gatherMaxMs: envInt('FM_WAITING_GATHER_MAX_MS', 45_000, 1_000),
+            gatherTakeMs: envInt('FM_WAITING_GATHER_TAKE_MS', 15_000, 1_000),
             max: envInt('FM_WAITING_ROOM_MAX', 2_000, 1),
             ttlMs: envInt('FM_WAITING_ROOM_TTL_MS', 3_600_000, 1_000),
             sweepMs: envInt('FM_WAITING_ROOM_SWEEP_MS', 60_000, 1_000),

--- a/backend/src/model/ShellyDeviceFactory.ts
+++ b/backend/src/model/ShellyDeviceFactory.ts
@@ -82,6 +82,15 @@ function deriveMethodsFromSettings(settings: unknown): string[] {
     return Array.from(out);
 }
 
+// Every probe RPC gets a deadline of its own plus, when the caller passes one,
+// the gather-wide abort. Without the per-call deadline an RPC falls back to
+// the 60s stale sweep, and the paginated probes below multiply that by up to
+// 100 pages; without the gather-wide signal a reclaim can't unwind them.
+function probeSignal(signal?: AbortSignal): AbortSignal {
+    const perCall = AbortSignal.timeout(tuning.rpc.initProbeTimeoutMs);
+    return signal ? AbortSignal.any([signal, perCall]) : perCall;
+}
+
 export function shouldProbeVirtualComponents(methods: string[]): boolean {
     // Ask any device that can list its components. The advertised method list
     // is the single source of truth — no firmware-version or capability guess.
@@ -89,12 +98,12 @@ export function shouldProbeVirtualComponents(methods: string[]): boolean {
 }
 
 export default class ShellyDeviceFactory {
-    static fromHttp(transport: HttpTransport) {
-        return ShellyDeviceFactory.fromOnlineTransport(transport);
+    static fromHttp(transport: HttpTransport, signal?: AbortSignal) {
+        return ShellyDeviceFactory.fromOnlineTransport(transport, signal);
     }
 
-    static fromWebsocket(transport: WebSocketTransport) {
-        return ShellyDeviceFactory.fromOnlineTransport(transport);
+    static fromWebsocket(transport: WebSocketTransport, signal?: AbortSignal) {
+        return ShellyDeviceFactory.fromOnlineTransport(transport, signal);
     }
 
     static fromDatabase(entry: get_resp_t): ShellyDevice | undefined {
@@ -142,7 +151,8 @@ export default class ShellyDeviceFactory {
     }
 
     private static async getData(
-        transport: RpcTransport
+        transport: RpcTransport,
+        signal?: AbortSignal
     ): Promise<
         [
             info: any,
@@ -156,32 +166,31 @@ export default class ShellyDeviceFactory {
         // RPC can't drag the other 3 down. Per-call abort signal at 20s
         // (gRPC keepalive default) cuts hold time vs the 60s rpcTimeoutMs
         // fallback, so a slow device frees its init slot 3× faster.
-        const timeoutMs = tuning.rpc.initProbeTimeoutMs;
         const [infoRes, statusRes, configRes, methodsRes] =
             await Promise.allSettled([
                 transport.sendRPC(
                     'Shelly.GetDeviceInfo',
                     null,
                     false,
-                    AbortSignal.timeout(timeoutMs)
+                    probeSignal(signal)
                 ),
                 transport.sendRPC(
                     'Shelly.GetStatus',
                     null,
                     false,
-                    AbortSignal.timeout(timeoutMs)
+                    probeSignal(signal)
                 ),
                 transport.sendRPC(
                     'Shelly.GetConfig',
                     null,
                     false,
-                    AbortSignal.timeout(timeoutMs)
+                    probeSignal(signal)
                 ),
                 transport.sendRPC(
                     'Shelly.ListMethods',
                     null,
                     false,
-                    AbortSignal.timeout(timeoutMs)
+                    probeSignal(signal)
                 )
             ]);
         if (infoRes.status === 'rejected') throw infoRes.reason;
@@ -203,13 +212,17 @@ export default class ShellyDeviceFactory {
         return [info, status, config, deriveCapabilities(methods), methods];
     }
 
-    private static async fromOnlineTransport(transport: RpcTransport) {
+    private static async fromOnlineTransport(
+        transport: RpcTransport,
+        signal?: AbortSignal
+    ) {
         // Per-stage timing — a device that shows up slowly after accept is slow
         // in exactly one of these probe steps; the log below names which.
         const timer = new StageTimer();
         const bundle = await ShellyDeviceFactory.gatherOverTransport(
             transport,
-            timer
+            timer,
+            signal
         );
         return ShellyDeviceFactory.assembleOverTransport(
             transport,
@@ -224,10 +237,11 @@ export default class ShellyDeviceFactory {
     // be reused at accept. Marks the shared timer's probe stages.
     private static async gatherOverTransport(
         transport: RpcTransport,
-        timer: StageTimer
+        timer: StageTimer,
+        signal?: AbortSignal
     ): Promise<DeviceDataBundle> {
         const [info, status, config, capabilities, methods] =
-            await ShellyDeviceFactory.getData(transport);
+            await ShellyDeviceFactory.getData(transport, signal);
         timer.mark('probe');
 
         let componentPages = 0;
@@ -235,22 +249,27 @@ export default class ShellyDeviceFactory {
             componentPages = await addVirtualComponents(
                 transport,
                 status,
-                config
+                config,
+                signal
             );
         }
         timer.mark('components');
 
         // XT1 service devices: fetch service metadata (actions, errors, resources)
         if (capabilities.service) {
-            await fetchServiceMeta(transport, config);
+            await fetchServiceMeta(transport, config, signal);
         }
         timer.mark('service');
 
         // LedStrip: stash per-firmware catalogs so the UI renders dynamically.
-        await fetchLedStripMeta(transport, config);
+        await fetchLedStripMeta(transport, config, signal);
         timer.mark('ledstrip');
 
-        const eventCatalog = await fetchEventCatalog(transport, info.fw_id);
+        const eventCatalog = await fetchEventCatalog(
+            transport,
+            info.fw_id,
+            signal
+        );
         timer.mark('eventcatalog');
 
         return {
@@ -300,11 +319,13 @@ export default class ShellyDeviceFactory {
     // Gather device data over a live socket WITHOUT building the device, so the
     // waiting room can pre-warm the heavy fetch while a device sits idle.
     static gatherDeviceData(
-        transport: RpcTransport
+        transport: RpcTransport,
+        signal?: AbortSignal
     ): Promise<DeviceDataBundle> {
         return ShellyDeviceFactory.gatherOverTransport(
             transport,
-            new StageTimer()
+            new StageTimer(),
+            signal
         );
     }
 
@@ -346,16 +367,22 @@ const MAX_COMPONENT_PAGES = 100;
 async function addVirtualComponents(
     transport: RpcTransport,
     deviceStatus: any,
-    deviceConfig: any
+    deviceConfig: any,
+    signal?: AbortSignal
 ): Promise<number> {
     let offset = 0;
     let total = 0;
     let pages = 0;
     for (let pageIndex = 0; pageIndex < MAX_COMPONENT_PAGES; pageIndex++) {
-        const result = await transport.sendRPC('Shelly.GetComponents', {
-            offset,
-            dynamic_only: true
-        });
+        // Checked per page so a gather-wide deadline ends the loop here
+        // instead of after up to 100 more pages.
+        signal?.throwIfAborted();
+        const result = await transport.sendRPC(
+            'Shelly.GetComponents',
+            {offset, dynamic_only: true},
+            false,
+            probeSignal(signal)
+        );
         pages++;
         total = result.total;
         const components = result.components;
@@ -388,9 +415,16 @@ async function addVirtualComponents(
  * JWT and the JSON-RPC API both allow N > 0). Stored under each component's
  * own key in config so the entity composer surfaces per-service metadata.
  */
-async function fetchServiceMeta(transport: RpcTransport, deviceConfig: any) {
+async function fetchServiceMeta(
+    transport: RpcTransport,
+    deviceConfig: any,
+    signal?: AbortSignal
+) {
     for (const id of listServiceIds(deviceConfig)) {
-        await fetchOneServiceMeta(transport, deviceConfig, id);
+        // The helpers below swallow their own failures by design, so check
+        // here — otherwise a gather-wide abort wouldn't end the loop.
+        signal?.throwIfAborted();
+        await fetchOneServiceMeta(transport, deviceConfig, id, signal);
     }
 }
 
@@ -407,21 +441,34 @@ function listServiceIds(deviceConfig: Record<string, unknown>): number[] {
 async function fetchOneServiceMeta(
     transport: RpcTransport,
     deviceConfig: any,
-    id: number
+    id: number,
+    signal?: AbortSignal
 ): Promise<void> {
     const svcKey = `service:${id}`;
-    await safeFetchServiceInfo(transport, deviceConfig, svcKey, id);
-    await safeFetchServiceConfigOptions(transport, deviceConfig, svcKey, id);
+    await safeFetchServiceInfo(transport, deviceConfig, svcKey, id, signal);
+    await safeFetchServiceConfigOptions(
+        transport,
+        deviceConfig,
+        svcKey,
+        id,
+        signal
+    );
 }
 
 async function safeFetchServiceInfo(
     transport: RpcTransport,
     deviceConfig: any,
     svcKey: string,
-    id: number
+    id: number,
+    signal?: AbortSignal
 ): Promise<void> {
     try {
-        const info = await transport.sendRPC('Service.GetInfo', {id});
+        const info = await transport.sendRPC(
+            'Service.GetInfo',
+            {id},
+            false,
+            probeSignal(signal)
+        );
         if (!info || typeof info !== 'object') return;
         if (!deviceConfig[svcKey] || typeof deviceConfig[svcKey] !== 'object') {
             return;
@@ -443,10 +490,16 @@ async function safeFetchServiceConfigOptions(
     transport: RpcTransport,
     deviceConfig: any,
     svcKey: string,
-    id: number
+    id: number,
+    signal?: AbortSignal
 ): Promise<void> {
     try {
-        const opts = await transport.sendRPC('Service.ListConfigOptions', {id});
+        const opts = await transport.sendRPC(
+            'Service.ListConfigOptions',
+            {id},
+            false,
+            probeSignal(signal)
+        );
         if (!opts?.props || !Array.isArray(opts.props)) return;
         if (!deviceConfig[svcKey] || typeof deviceConfig[svcKey] !== 'object') {
             return;
@@ -512,12 +565,16 @@ export {MAX_CATALOG_PAGES};
 // Exported for tests only.
 export async function fetchEventCatalog(
     transport: RpcTransport,
-    fwId: string | undefined
+    fwId: string | undefined,
+    signal?: AbortSignal
 ): Promise<DeviceEventCatalog | undefined> {
     const pages = [];
     let offset = 0;
     for (let pageIndex = 0; pageIndex < MAX_CATALOG_PAGES; pageIndex++) {
-        const page = await safeFetchCatalogPage(transport, offset);
+        // safeFetchCatalogPage swallows failures, so an abort has to end the
+        // loop here rather than through its return value.
+        signal?.throwIfAborted();
+        const page = await safeFetchCatalogPage(transport, offset, signal);
         if (!page) {
             return pages.length > 0
                 ? buildEventCatalog({pages, nowMs: Date.now(), fwId})
@@ -551,12 +608,16 @@ function warnPartialCatalogIfShort(
 
 async function safeFetchCatalogPage(
     transport: RpcTransport,
-    offset: number
+    offset: number,
+    signal?: AbortSignal
 ): Promise<{types?: ReadonlyArray<any>; total?: number} | null> {
     try {
-        const resp = await transport.sendRPC('Webhook.ListAllSupported', {
-            offset
-        });
+        const resp = await transport.sendRPC(
+            'Webhook.ListAllSupported',
+            {offset},
+            false,
+            probeSignal(signal)
+        );
         if (!resp || typeof resp !== 'object') return null;
         return resp as {types?: ReadonlyArray<any>; total?: number};
     } catch (err) {
@@ -583,10 +644,18 @@ function errorMessage(err: unknown): string {
 
 async function fetchLedStripMeta(
     transport: RpcTransport,
-    deviceConfig: Record<string, any>
+    deviceConfig: Record<string, any>,
+    signal?: AbortSignal
 ): Promise<void> {
     for (const key of ledStripKeys(deviceConfig)) {
-        await loadCatalogForLedStrip(transport, {config: deviceConfig, key});
+        // Same reason as the service loop: the catalog fetch below is
+        // best-effort, so the abort check belongs here.
+        signal?.throwIfAborted();
+        await loadCatalogForLedStrip(
+            transport,
+            {config: deviceConfig, key},
+            signal
+        );
     }
 }
 
@@ -618,12 +687,13 @@ interface ArrayFetchSpec {
 
 async function loadCatalogForLedStrip(
     transport: RpcTransport,
-    target: Omit<LedStripTarget, 'id'>
+    target: Omit<LedStripTarget, 'id'>,
+    signal?: AbortSignal
 ): Promise<void> {
     const id = parseComponentId(target.key);
     if (id === null) return;
     const fullTarget: LedStripTarget = {...target, id};
-    const catalog = await fetchLedStripCatalog(transport, id);
+    const catalog = await fetchLedStripCatalog(transport, id, signal);
     if (catalogIsEmpty(catalog)) return;
     stashCatalogOnConfig(fullTarget, catalog);
     stashUiFieldsOnConfig(fullTarget, {
@@ -634,20 +704,21 @@ async function loadCatalogForLedStrip(
 
 async function fetchLedStripCatalog(
     transport: RpcTransport,
-    id: number
+    id: number,
+    signal?: AbortSignal
 ): Promise<LedStripCatalog> {
     const [protocols, palettes, effects] = await Promise.all([
-        safeFetchArrayField(transport, {
-            id,
-            method: 'LedStrip.ListAllProtocols',
-            field: 'protocols'
-        }),
-        safeFetchArrayField(transport, {
-            id,
-            method: 'LedStrip.ListAllPalettes',
-            field: 'palettes'
-        }),
-        safeFetchAllEffects(transport, id)
+        safeFetchArrayField(
+            transport,
+            {id, method: 'LedStrip.ListAllProtocols', field: 'protocols'},
+            signal
+        ),
+        safeFetchArrayField(
+            transport,
+            {id, method: 'LedStrip.ListAllPalettes', field: 'palettes'},
+            signal
+        ),
+        safeFetchAllEffects(transport, id, signal)
     ]);
     return {
         protocols: protocols as string[] | undefined,
@@ -658,10 +729,16 @@ async function fetchLedStripCatalog(
 
 export async function safeFetchArrayField(
     transport: RpcTransport,
-    spec: ArrayFetchSpec
+    spec: ArrayFetchSpec,
+    signal?: AbortSignal
 ): Promise<unknown[] | undefined> {
     try {
-        const r = await transport.sendRPC(spec.method, {id: spec.id});
+        const r = await transport.sendRPC(
+            spec.method,
+            {id: spec.id},
+            false,
+            probeSignal(signal)
+        );
         const value = (r as Record<string, unknown>)?.[spec.field];
         return Array.isArray(value) ? value : undefined;
     } catch (err) {
@@ -672,10 +749,11 @@ export async function safeFetchArrayField(
 
 async function safeFetchAllEffects(
     transport: RpcTransport,
-    id: number
+    id: number,
+    signal?: AbortSignal
 ): Promise<unknown[] | undefined> {
     try {
-        return await paginateEffects(transport, id);
+        return await paginateEffects(transport, id, signal);
     } catch (err) {
         warnIfUnexpected('LedStrip.ListAllEffects', id, err);
         return undefined;
@@ -688,12 +766,13 @@ export const MAX_EFFECT_PAGES = 100;
 
 export async function paginateEffects(
     transport: RpcTransport,
-    id: number
+    id: number,
+    signal?: AbortSignal
 ): Promise<unknown[]> {
     const collected: unknown[] = [];
     let offset = 0;
     for (let pageIndex = 0; pageIndex < MAX_EFFECT_PAGES; pageIndex++) {
-        const page = await fetchEffectPage(transport, {id, offset});
+        const page = await fetchEffectPage(transport, {id, offset}, signal);
         if (page.length === 0) return collected;
         collected.push(...page);
         offset += page.length;
@@ -710,9 +789,15 @@ export async function paginateEffects(
 
 async function fetchEffectPage(
     transport: RpcTransport,
-    page: {id: number; offset: number}
+    page: {id: number; offset: number},
+    signal?: AbortSignal
 ): Promise<unknown[]> {
-    const r = await transport.sendRPC('LedStrip.ListAllEffects', page);
+    const r = await transport.sendRPC(
+        'LedStrip.ListAllEffects',
+        page,
+        false,
+        probeSignal(signal)
+    );
     const effects = (r as {effects?: unknown})?.effects;
     return Array.isArray(effects) ? effects : [];
 }

--- a/backend/src/model/transport/RpcTransport.ts
+++ b/backend/src/model/transport/RpcTransport.ts
@@ -30,6 +30,12 @@ export default abstract class RpcTransport {
     #shellyMessageMap = new Map<number, StoredMessage>();
     #uniqueID = 0;
     #intervalId: NodeJS.Timeout;
+    // Set by destroy(). A send after teardown can never be answered: the
+    // socket is gone (ws.send() is a silent no-op once closed — no throw for
+    // #failPending to catch) and destroy() has already stopped the stale
+    // sweeper, so the pending slot would sit there forever and its caller
+    // would await a promise nothing can settle.
+    #destroyed = false;
     protected _messageListeners: ShellyResponseCallback[] = [];
     protected _eventEmitter: ShellyDeviceEmitter;
 
@@ -88,6 +94,9 @@ export default abstract class RpcTransport {
         emitMessage = false,
         signal?: AbortSignal
     ) {
+        if (this.#destroyed) {
+            return Promise.reject(RpcError.Timeout());
+        }
         if (signal?.aborted) {
             return Promise.reject(signal.reason ?? new Error('aborted'));
         }
@@ -235,6 +244,9 @@ export default abstract class RpcTransport {
     }
 
     public destroy() {
+        // Before rejecting: a handler that reacts by issuing another RPC must
+        // fail fast rather than register a slot that outlives the sweeper.
+        this.#destroyed = true;
         const error = RpcError.Timeout();
         for (const handler of this.#shellyMessageMap.values()) {
             handler.cleanup?.();

--- a/backend/src/modules/deviceIngress/gatheredDeviceData.ts
+++ b/backend/src/modules/deviceIngress/gatheredDeviceData.ts
@@ -3,10 +3,20 @@
 // (single-flight — an accept clicked mid-gather shares the in-flight one). A
 // failed gather is not kept, so it's re-tried. The entry is dropped when the
 // device leaves the waiting room or is accepted.
+//
+// Every gather is deadline-bound and every wait on one is deadline-bound: a
+// gather that can't finish is abandoned rather than left in-flight for the
+// next connection to join, so one unresponsive device can't hold its own
+// init slot open forever.
 
+import {tuning} from '../../config';
 import type {DeviceDataBundle} from '../../model/ShellyDeviceFactory';
 import {BoundedMap} from '../boundedMap';
+// Direct counter import, not the Observability barrel — the barrel pulls in
+// the device model, which imports this module.
+import {incrementLabeledCounter} from '../observability/counters';
 import {SingleFlight} from '../singleFlight';
+import {TimeoutError, withTimeout} from '../util/withTimeout';
 
 const flight = new SingleFlight<string, DeviceDataBundle>('device-gather');
 // Bounded + TTL: a gather never consumed (device vanished before accept) is
@@ -17,29 +27,69 @@ const held = new BoundedMap<string, DeviceDataBundle>({
     maxSize: HELD_MAX,
     ttlMs: HELD_TTL_MS
 });
-// Keys whose in-flight gather was already taken by an accept — so the gather,
-// when it finishes, doesn't re-store a bundle that's already been consumed.
-const consumed = new Set<string>();
+// Per-device generation, bumped every time a running gather is abandoned (an
+// accept took it, its deadline passed, the socket went away). A gather that
+// finishes late compares the generation it started in against the current one
+// and, if they differ, hands its bundle to its own caller without re-storing
+// it — a bundle read over a connection that no longer exists must not be
+// served to the next accept.
+const generation = new BoundedMap<string, number>({
+    maxSize: HELD_MAX,
+    ttlMs: HELD_TTL_MS
+});
+
+function currentGeneration(shellyID: string): number {
+    return generation.get(shellyID) ?? 0;
+}
+
+// Abandon whatever gather is running for this device: later callers start a
+// fresh one, and the abandoned run's result is not stored when it lands.
+function abandonGather(shellyID: string, reason: string): void {
+    generation.set(shellyID, currentGeneration(shellyID) + 1);
+    if (!flight.peek(shellyID)) return;
+    flight.forget(shellyID);
+    incrementLabeledCounter('device_gather_abandoned_total', {reason});
+}
+
+export interface TakeGatheredOptions {
+    /** Overrides tuning.waitingRoom.gatherTakeMs. */
+    timeoutMs?: number;
+    /** The init slot's reclaim signal — abandons the wait when it fires. */
+    signal?: AbortSignal;
+}
 
 // Gather once and keep the result; a saved bundle or an in-flight gather is
-// reused. A rejection is not kept, so the next call re-gathers.
+// reused. A rejection is not kept, so the next call re-gathers. The gather is
+// deadline-bound: `gather` receives a signal that fires at
+// tuning.waitingRoom.gatherMaxMs and must pass it to its RPCs.
 export async function gatherDeviceDataOnce(
     shellyID: string,
-    gather: () => Promise<DeviceDataBundle>
+    gather: (signal: AbortSignal) => Promise<DeviceDataBundle>
 ): Promise<DeviceDataBundle> {
     const saved = held.get(shellyID);
     if (saved) return saved;
-    const bundle = await flight.run(shellyID, gather);
-    // An accept consumed the in-flight result while we gathered — don't re-store.
-    if (consumed.delete(shellyID)) return bundle;
+    const startedGeneration = currentGeneration(shellyID);
+    const bundle = await flight.run(shellyID, () =>
+        withTimeout(
+            gather,
+            tuning.waitingRoom.gatherMaxMs,
+            `device-gather ${shellyID}`
+        )
+    );
+    // Abandoned while we gathered — don't re-store a result nobody wants.
+    if (currentGeneration(shellyID) !== startedGeneration) return bundle;
     held.set(shellyID, bundle);
     return bundle;
 }
 
 // Remove and return the bundle for accept. If the gather is still running
-// (accept clicked mid-gather), await it instead of missing it and re-probing.
+// (accept clicked mid-gather), await it instead of missing it and re-probing —
+// but only up to `gatherTakeMs`, and only until the init slot is reclaimed.
+// Giving up returns undefined, so accept falls back to a fresh probe over its
+// own socket rather than blocking on a gather that may never land.
 export async function takeGatheredData(
-    shellyID: string
+    shellyID: string,
+    opts: TakeGatheredOptions = {}
 ): Promise<DeviceDataBundle | undefined> {
     const saved = held.get(shellyID);
     if (saved) {
@@ -48,18 +98,76 @@ export async function takeGatheredData(
     }
     const inflight = flight.peek(shellyID);
     if (!inflight) return undefined;
-    consumed.add(shellyID);
+    // Either way this run's result is spoken for: it goes to this accept, or
+    // it is given up on. It must not also be stored for the next one.
+    generation.set(shellyID, currentGeneration(shellyID) + 1);
     try {
-        return await inflight;
-    } catch {
-        // A failed gather isn't reusable — accept falls back to a fresh probe.
-        consumed.delete(shellyID);
+        return await raceTake(
+            inflight,
+            opts.timeoutMs ?? tuning.waitingRoom.gatherTakeMs,
+            opts.signal
+        );
+    } catch (err) {
+        // Timed out, reclaimed, or the gather failed — a run we're no longer
+        // waiting on must not be handed to the next connection either.
+        abandonGather(shellyID, takeFailureReason(err));
         return undefined;
     }
 }
 
+function takeFailureReason(err: unknown): string {
+    if (err instanceof TimeoutError) return 'take_timeout';
+    if (err instanceof Error && err.name === 'AbortError') return 'reclaimed';
+    return 'gather_failed';
+}
+
+// Bounded wait on a promise we don't own. `inflight` can't be cancelled from
+// here — it belongs to the gather — so this only stops waiting on it; the
+// caller abandons the run.
+function raceTake(
+    inflight: Promise<DeviceDataBundle>,
+    timeoutMs: number,
+    signal?: AbortSignal
+): Promise<DeviceDataBundle> {
+    return withTimeout(
+        (timeoutSignal) => {
+            if (!signal) return inflight;
+            return Promise.race([
+                inflight,
+                abortRejection(AbortSignal.any([signal, timeoutSignal]))
+            ]);
+        },
+        timeoutMs,
+        'gather-take'
+    );
+}
+
+function abortRejection(signal: AbortSignal): Promise<never> {
+    return new Promise<never>((_, reject) => {
+        if (signal.aborted) {
+            reject(abortError(signal));
+            return;
+        }
+        signal.addEventListener('abort', () => reject(abortError(signal)), {
+            once: true
+        });
+    });
+}
+
+function abortError(signal: AbortSignal): Error {
+    const reason = signal.reason;
+    if (reason instanceof Error) return reason;
+    const err = new Error(String(reason ?? 'aborted'));
+    err.name = 'AbortError';
+    return err;
+}
+
 export function dropGatheredData(shellyID: string): void {
     held.delete(shellyID);
+    // The socket this gather reads over is gone. Drop the in-flight entry too,
+    // or the device's next connection dedups onto a run bound to a dead
+    // transport and waits out the init-slot watchdog for nothing.
+    abandonGather(shellyID, 'socket_closed');
 }
 
 export function hasGatheredData(shellyID: string): boolean {
@@ -68,5 +176,8 @@ export function hasGatheredData(shellyID: string): boolean {
 
 export function clearGatheredDataForTests(): void {
     held.clear();
-    consumed.clear();
+    generation.clear();
+    // Also drop in-flight runs — a hung gather left over from one case would
+    // otherwise be dedup'd onto by the next and sit out the whole deadline.
+    flight.clear();
 }

--- a/backend/src/modules/singleFlight.ts
+++ b/backend/src/modules/singleFlight.ts
@@ -39,6 +39,22 @@ export class SingleFlight<K, V> {
         return this.#inflight.get(key);
     }
 
+    /**
+     * Stop deduping onto the run for `key`. The run itself is untouched — it
+     * settles on its own — but the next caller starts a fresh one instead of
+     * joining a run whose result is no longer wanted (its socket is gone, its
+     * deadline has passed). Without this, one caller giving up leaves the
+     * entry behind for every later caller to join.
+     */
+    forget(key: K): void {
+        this.#inflight.delete(key);
+    }
+
+    /** Test-reset only: forget every key at once. */
+    clear(): void {
+        this.#inflight.clear();
+    }
+
     size(): number {
         return this.#inflight.size;
     }

--- a/backend/src/modules/web/ws/handlers/ShellyWebsocketHandler.ts
+++ b/backend/src/modules/web/ws/handlers/ShellyWebsocketHandler.ts
@@ -686,8 +686,10 @@ export default class ShellyWebsocketHandler extends AbstractWebsocketHandler {
         const transport = session.transport;
         const startedAt = Date.now();
         void runBoundedGather(async () => {
-            const bundle = await gatherDeviceDataOnce(shellyID, () =>
-                ShellyDeviceFactory.gatherDeviceData(transport)
+            // The signal carries the gather-wide deadline down into every
+            // probe RPC, so this task always frees its concurrency slot.
+            const bundle = await gatherDeviceDataOnce(shellyID, (signal) =>
+                ShellyDeviceFactory.gatherDeviceData(transport, signal)
             );
             ingressStage(
                 shellyID,
@@ -1058,7 +1060,8 @@ export default class ShellyWebsocketHandler extends AbstractWebsocketHandler {
                     session: ctx.session,
                     admittedShellyID: ctx.shellyID,
                     message: ctx.message,
-                    setStage: ctx.handle.setStage
+                    setStage: ctx.handle.setStage,
+                    signal: ctx.handle.signal
                 },
                 this.#admissionDeps
             );

--- a/backend/src/modules/web/ws/handlers/shellyAdmissionFlow.ts
+++ b/backend/src/modules/web/ws/handlers/shellyAdmissionFlow.ts
@@ -46,9 +46,12 @@ export interface AdmissionDeps {
     factory: Pick<typeof ShellyDeviceFactory, 'fromWebsocket'> &
         Partial<Pick<typeof ShellyDeviceFactory, 'assembleFromGathered'>>;
     // Data gathered while the device waited, if any. Present → accept assembles
-    // from it (no re-fetch); absent → build over the socket, as before.
+    // from it (no re-fetch); absent → build over the socket, as before. The
+    // signal is the init slot's, so a reclaim ends the wait instead of leaving
+    // it pinned to a gather that may never land.
     takeGatheredData?: (
-        shellyID: string
+        shellyID: string,
+        opts?: {signal?: AbortSignal}
     ) => Promise<DeviceDataBundle | undefined>;
     deviceCollector: Pick<typeof DeviceCollector, 'register'>;
     auditLogger: Pick<typeof AuditLogger, 'log'>;
@@ -68,6 +71,10 @@ export interface AdmittedRegistrationInput {
     message: InitMessage;
     // Marks init phase for the slot watchdog, so a reclaim names where it stuck.
     setStage?: (stage: InitStage) => void;
+    // Aborted when the slot watchdog reclaims this init. Threaded into the
+    // gather wait and the probe RPCs so a reclaim actually unwinds the work,
+    // rather than freeing the slot while the build runs on underneath it.
+    signal?: AbortSignal;
 }
 
 // Top-level error wrapper. Pure error handling — no business logic.
@@ -107,7 +114,7 @@ async function runRegistration(
     input: AdmittedRegistrationInput,
     deps: AdmissionDeps
 ): Promise<boolean> {
-    const {session, admittedShellyID, message} = input;
+    const {session, admittedShellyID, message, signal} = input;
     const initStart = Date.now();
     const initialStatus = initialStatusFor(message);
 
@@ -121,7 +128,7 @@ async function runRegistration(
     const transport = session.transport ?? deps.buildTransport(session.ws);
     // Reuse the data gathered while the device waited, if any; otherwise gather
     // it now over the socket (a slow or early-accepted device just does it here).
-    const gathered = await deps.takeGatheredData?.(admittedShellyID);
+    const gathered = await deps.takeGatheredData?.(admittedShellyID, {signal});
     // Reuse should dominate; a spike in fresh probes means accepts are
     // outrunning the gather.
     const reusedGather = Boolean(gathered && deps.factory.assembleFromGathered);
@@ -133,7 +140,7 @@ async function runRegistration(
     const shelly =
         gathered && deps.factory.assembleFromGathered
             ? await deps.factory.assembleFromGathered(transport, gathered)
-            : await deps.factory.fromWebsocket(transport);
+            : await deps.factory.fromWebsocket(transport, signal);
 
     const mismatch = checkAdmittedIdentity(admittedShellyID, shelly.shellyID);
     if (mismatch !== null) {


### PR DESCRIPTION
Fixes #30.
Fixes #28 — same bug, reported a week earlier with device-side evidence.

A device whose pre-gather never finishes gets stuck in a permanent `connect → slot-acquired → "Registering new websocket client" → 90s watchdog reclaim → reconnect` loop, while identical devices on the same server register in ~2s. The init-slot watchdog frees the slot but never ends the work holding it, so the same device comes straight back and does it again.

Full analysis in #30. Short version — three unbounded waits stack up:

1. Only the four base RPCs in `getData()` carry an `AbortSignal`. `Shelly.GetComponents`, `Service.GetInfo`, `Service.ListConfigOptions`, `Webhook.ListAllSupported` and the `LedStrip.*` probes fall back to the 60s `rpcTimeoutMs` stale sweep — and three of those run in loops capped at 100 pages, so a gather can run for over an hour without any single RPC being "hung". `gatherOverTransport()` has no overall budget either.
2. `takeGatheredData()` does a bare `await inflight`. That's the first `await` in `runRegistration()`, right after the log line the stuck devices stop at, with `stage=build` — matching the watchdog output.
3. `SingleFlight` only drops an entry when its run settles, and `dropGatheredData()` on close clears only `held`. A gather that outlives its connection stays joinable, so the device's next connection dedups onto a run bound to a transport that's already gone.

`SlotHandle.signal` exists for exactly this case ("so the init it guards unwinds") but never reached the gather: `closeSocketOnReclaim` closes the *current* socket, which does nothing for a gather belonging to a previous one.

## Changes

**`ShellyDeviceFactory`**
- New `probeSignal(signal?)`: every probe RPC now gets its own `initProbeTimeoutMs` deadline, combined via `AbortSignal.any` with the gather-wide signal when one is passed.
- The signal is threaded through `gatherOverTransport()` into all the paginated probes, and `fromWebsocket()` / `fromHttp()` accept one so the accept-path build is covered too.
- `signal?.throwIfAborted()` per iteration in the component, service, catalog and ledstrip loops. This is load-bearing: those helpers swallow their own failures by design, so without it an abort wouldn't end the loop.

**`gatheredDeviceData`**
- `gatherDeviceDataOnce()` wraps the gather in a hard deadline (`waitingRoom.gatherMaxMs`, default 45s — under the 90s slot cap) using the existing `withTimeout` util, so the single-flight entry and the gather concurrency slot always free.
- `takeGatheredData()` takes a deadline (`waitingRoom.gatherTakeMs`, default 15s) and the init slot's signal. Giving up abandons the run and returns `undefined`, so accept falls back to a fresh probe over its own socket instead of waiting out the watchdog.
- `dropGatheredData()` drops the in-flight run too, not just the bundle.
- A per-device generation counter replaces the `consumed` set. Same purpose — don't re-store a bundle that's already been taken — but it also handles the case the old ordering got wrong: once a run can be abandoned while a fresh one starts, `consumed` let the *stale* run's bundle overwrite the new one depending on which landed first.

**`SingleFlight`**
- `forget(key)` so an abandoned run stops being joinable, and `clear()` for test resets.

**`shellyAdmissionFlow` / `ShellyWebsocketHandler`**
- `AdmittedRegistrationInput` carries the init slot's `signal`, passed into `takeGatheredData` and the fallback build. A reclaim now actually unwinds the init instead of just freeing the slot.

**`tuning`**
- `waitingRoom.gatherMaxMs` (`FM_WAITING_GATHER_MAX_MS`, default 45000)
- `waitingRoom.gatherTakeMs` (`FM_WAITING_GATHER_TAKE_MS`, default 15000)

New labeled counter `device_gather_abandoned_total{reason}` — `take_timeout` / `reclaimed` / `gather_failed` / `socket_closed` — so this is visible next to `device_init_slot_reclaimed_total` instead of only showing up as a reclaim.

## Behaviour when healthy

Unchanged. The gather still runs once per device, accept still reuses it, and `device_accept_gather_reused` should still dominate `device_accept_fresh_probe`. The new deadlines only fire on a gather that was already going to blow the 90s slot cap.

## Verification

- `tsc --noEmit` clean.
- `biome check` clean on all six changed files.
- Behaviour verified against a gather that never settles:
  - accept gives up after the take deadline and falls back to a fresh probe (206ms with a 200ms deadline, instead of hanging)
  - the next connection starts its own gather rather than joining the abandoned one
  - an init-slot reclaim unwinds the wait immediately (59ms) rather than after the full deadline
  - a socket close drops the in-flight run, so a reconnect doesn't join it
  - the happy path still pre-warms once and is reused at accept

I didn't add these as committed tests because `test/` isn't part of this repo — happy to add them in whatever form suits if you point me at the suite. Both new timeouts are env-tunable, so they can also be tightened or relaxed without a redeploy.

## Notes / follow-ups not in this PR

`BoundedConcurrency.run()` also does a bare `await fn()`. With the gather now deadline-bound its slot always frees, so this is no longer reachable from the gather path — but the class itself still has no deadline of its own, which seemed worth mentioning separately rather than widening this change.

