### PR TITLE
fix(authz): reject unknown actions in the simulator instead of answering them

### DIFF
--- a/backend/src/modules/authz/actionMap.ts
+++ b/backend/src/modules/authz/actionMap.ts
@@ -23,6 +23,25 @@ export function authzAction(
     return `${resourceType}:${operation}`;
 }
 
+/**
+ * Throws unless `action` is one this policy vocabulary can actually emit.
+ *
+ * Callers that take an action from a client (the authz simulator) need this:
+ * an unrecognised string is not "denied", it is unanswerable. Matched against
+ * a persona holding a wildcard grant it comes back allowed, which is worse
+ * than no answer at all.
+ */
+export function assertKnownAuthzAction(action: string): void {
+    const vocabulary = enumerateActionVocabulary();
+    if (vocabulary.has(action)) return;
+    // Name a few real actions — the usual mistake is passing an RPC method
+    // name (`admin.PostgresCall`) where a policy action (`device:read`) goes.
+    const sample = [...vocabulary].slice(0, 3).join(', ');
+    throw new Error(
+        `unknown authz action '${action}' — expected a policy action such as ${sample}`
+    );
+}
+
 // Actions authzAction() emits. Devices: read/execute/write only.
 let cachedRealActions: Set<string> | undefined;
 

--- a/backend/src/modules/user/UserComponent.ts
+++ b/backend/src/modules/user/UserComponent.ts
@@ -19,6 +19,7 @@ import {AUTHZ_SYSTEM_PERSONA_KEYS} from '../../types/api/authzCatalog';
 import {USERNAME_UPLOAD_TICKET_PARAMS_SCHEMA} from '../../types/api/upload';
 import {USER_DESCRIBE} from '../../types/api/user';
 import * as AuditLogger from '../AuditLogger';
+import {assertKnownAuthzAction} from '../authz/actionMap';
 import {createAssignmentGrant, loadAttachablePersona} from '../authz/admin';
 import {
     canCrossOrganizationBoundary,
@@ -418,6 +419,19 @@ export default class UserComponent extends Component<UserComponentConfig> {
         if (!params?.userId || !params.action || !params.resourceType) {
             throw RpcError.InvalidParams(
                 'userId, action, resourceType required'
+            );
+        }
+        // The action has to be one the policy vocabulary actually contains.
+        // Without this check an unrecognised string — an RPC method name, a
+        // typo — is still matched against the target's statements, and a
+        // persona holding a wildcard grant answers "allowed" for an action
+        // that does not exist. That is the opposite of what this endpoint is
+        // for: it exists to explain why an assignment does or does not apply.
+        try {
+            assertKnownAuthzAction(params.action);
+        } catch (err) {
+            throw RpcError.InvalidParams(
+                err instanceof Error ? err.message : String(err)
             );
         }
         const tenantId = sender.getOrganizationId();


### PR DESCRIPTION
Part of #43 — the unknown-action half.

Deliberately **not** marked with a closing keyword: the second half of that issue, the component permission gates the resolver never evaluates, is untouched here and should stay open after this merges. See *What this does not fix* below.

`User.SimulateV2` checked that `action` was non-empty and passed it straight to the resolver. The resolver matches that string against the target's statements, so a persona holding a wildcard grant returns **Allowed** for an action that does not exist.

The policy vocabulary is 78 entries of the form `resource:operation`:

```
device:write, device:read, device:execute, action:create, action:read, …
```

An RPC method name is not among them, and neither is a typo:

```
admin.PostgresCall  -> allowed   (before)
device:reed         -> allowed   (before)
```

That is the opposite of what the endpoint is for. It is reached from the UI's *"can this user perform an action on a resource? Useful to debug why an assignment is or isn't taking effect"* panel, so a false Allowed gets acted on — the operator grants the persona, sees green, and concludes the assignment works while every real call keeps returning 403.

## The change

`assertKnownAuthzAction()` sits next to `enumerateActionVocabulary()` in `actionMap.ts`, which already owns the set. `SimulateV2` surfaces it as `InvalidParams`, and the message names three real actions because the usual mistake is passing an RPC method name where a policy action goes:

```
admin.PostgresCall     -> unknown authz action 'admin.PostgresCall' — expected a
                          policy action such as device:write, device:read, device:execute
device:reed            -> unknown authz action 'device:reed' — …
device:read            -> accepted
*                      -> unknown authz action '*' — …
```

Wildcards are rejected deliberately: `*` is a grant pattern, not something to simulate. `patternMatchesRealAction()` already handles that case separately and is untouched.

33 lines, two files, no behaviour change for any action that was already valid. `tsc --noEmit` and `biome check` clean.

## What this does not fix

The second half of #43. An action can be valid, granted, and still refused at runtime, because the component carries a `@Component.CheckPermissions()` gate the resolver never sees. `admin.PostgresCall` requires `canUsePlatformAdmin`, which resolves to `sender.isPlatformAdmin()` — a Zitadel role that no persona or assignment can grant.

28 methods sit behind such gates (19 `canUsePlatformAdmin`, 7 `canCrossOrganizationBoundary`, 2 `canUseTenantAdmin`), across `AdminComponent`, `AlexaComponent`, `DomainPolicyComponent`, `MailComponent`, `NotificationComponent`, `PermissionComponent`, `PluginManagerComponent` and `PolicyComponent`.

Teaching the simulator to model both layers is a larger change and a design decision — whether to evaluate the gate, or to report a third outcome such as *"allowed by assignments, blocked by a component gate"*. I left it out rather than guess at the intended shape, but I am happy to follow up with whichever you prefer.

Worth noting that the generated catalog already distinguishes the two: 857 methods carry `permission: {component, operation}`, while 352 carry only a human-readable `permission: {note}`. The second group is essentially the set the assignment system cannot speak for.

